### PR TITLE
fix(tests): align KB-match marker assertions with content-library rename

### DIFF
--- a/tests/unit/agents/proposal-writer.test.ts
+++ b/tests/unit/agents/proposal-writer.test.ts
@@ -154,13 +154,13 @@ describe('proposal-writer (F8 interface)', () => {
       expect(args.system).toContain('source blockquote')
     })
 
-    it('system prompt includes "No knowledge base match" gap indicator', async () => {
+    it('system prompt includes "No content library match" gap indicator', async () => {
       vi.mocked(generateText).mockResolvedValue({ text: mockMarkdown } as unknown as Awaited<ReturnType<typeof generateText>>)
 
       await writeProposal(baseInput)
 
       const args = vi.mocked(generateText).mock.calls[0]![0] as { system: string }
-      expect(args.system).toContain('No knowledge base match')
+      expect(args.system).toContain('No content library match')
     })
 
     it('prompt includes KB entry titles in knowledge base context', async () => {

--- a/tests/unit/services/kb-coverage-metric.test.ts
+++ b/tests/unit/services/kb-coverage-metric.test.ts
@@ -14,7 +14,7 @@ Content here.
 Content here.
 
 ## Section 3
-> *Source: No knowledge base match — consider uploading relevant content*
+> *Source: No content library match — consider uploading relevant content*
 Content here.
 
 ## Section 4
@@ -34,7 +34,7 @@ Content here.
 Content here.
 
 ## Section 8
-> *Source: No knowledge base match — consider uploading relevant content*
+> *Source: No content library match — consider uploading relevant content*
 Content here.
 
 ## Section 9
@@ -52,10 +52,10 @@ Content here.`
     const markdown = `# Proposal
 
 ## Section 1
-> *Source: No knowledge base match — consider uploading relevant content*
+> *Source: No content library match — consider uploading relevant content*
 
 ## Section 2
-> *Source: No knowledge base match — consider uploading relevant content*`
+> *Source: No content library match — consider uploading relevant content*`
 
     expect(computeKbCoveragePercentage(markdown)).toBe(0)
   })


### PR DESCRIPTION
## Summary

- Production code in `src/lib/services/kb-coverage-metric.ts` and `src/lib/ai/agents/proposal-writer.ts` uses the marker string `"No content library match"` after a rename from `"No knowledge base match"`.
- Two test files were not updated, causing CI failures:
  - `kb-coverage-metric.test.ts` seeded markdown with the old marker, so `computeKbCoveragePercentage` correctly didn't recognize it as a no-match sentinel and returned 100% instead of 80%/0%.
  - `proposal-writer.test.ts` asserted the old marker against the live system prompt.
- Updated 6 string literals across the two test files to match production.

## Test plan

- [x] `npx vitest --run tests/unit/services/kb-coverage-metric.test.ts tests/unit/agents/proposal-writer.test.ts` — 42/42 pass
- [ ] CI green on this branch