### PR TITLE
chore(deps): override protobufjs to patched versions (Dependabot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,22 +1402,22 @@
       }
     },
     "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -4074,9 +4074,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4102,9 +4102,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -4120,9 +4120,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
@@ -13808,22 +13808,12 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
+      "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "esbuild": ">=0.25.0"
+    "esbuild": ">=0.25.0",
+    "@grpc/proto-loader": {
+      "protobufjs": "^7.5.6"
+    },
+    "@opentelemetry/otlp-transformer": {
+      "protobufjs": "^8.0.3"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds two scoped npm overrides to force the patched protobufjs versions through inngest's OpenTelemetry transitive chain, closing the two critical Dependabot alerts on protobufjs 7.5.5 and 8.0.1.

**Before:**
- \`@grpc/proto-loader\` → protobufjs 7.5.5 (vulnerable)
- \`@opentelemetry/otlp-transformer\` → protobufjs 8.0.1 (vulnerable)

**After:**
- \`@grpc/proto-loader\` → protobufjs 7.5.6 (patched)
- \`@opentelemetry/otlp-transformer\` → protobufjs 8.0.3 (patched)

Override is scoped (not blanket) so each OTel parent still gets the major version it expects — minimal blast radius. Upstream packages have not yet re-pinned, so this bridges the gap until they do.

## Why scoped, not blanket

A top-level \`"protobufjs": "^8.0.3"\` override would force \`@grpc/proto-loader\` (designed for 7.x) onto 8.x and risks runtime decode mismatches. Scoping per-parent preserves each consumer's intended major.

## Test plan

- [x] \`npm install\` clean — overrides resolve as expected (\`npm ls protobufjs\` shows 7.5.6 + 8.0.3)
- [x] \`npm run build\` succeeds
- [ ] CI green (local vitest hangs under WSL with piped stdio; deferred to CI)
- [ ] After merge: confirm Dependabot rescan closes both protobufjs alerts
- [ ] Smoke test: trigger an inngest function in preview deploy and confirm OTel traces still ship without decode errors

## Out of scope

- @xmldom/xmldom + underscore (mammoth pins; no upstream fix yet)
- next 15→16 codemod
- drizzle-orm + yaml advisory verification
- flatted + picomatch 2.x dismissals (dev-only)