### PR TITLE
fix: store uploaded documents as private blobs

### DIFF
--- a/scripts/migrate-blobs-to-private.ts
+++ b/scripts/migrate-blobs-to-private.ts
@@ -1,0 +1,78 @@
+/**
+ * One-time migration: re-uploads every public blob in the store as private.
+ *
+ * Blobs uploaded before fix/private-blob-access were created with
+ * access: 'public'. This script lists all blobs, detects public ones by
+ * attempting an unauthenticated fetch (private blobs return 403), and
+ * re-puts each at the same pathname with access: 'private'. Pathnames are
+ * deterministic (no random suffix), so blob URLs stored in the database
+ * remain valid after migration.
+ *
+ * Usage:
+ *   BLOB_READ_WRITE_TOKEN=... npx tsx scripts/migrate-blobs-to-private.ts
+ *
+ * Safe to re-run: already-private blobs are skipped.
+ */
+import { list, put } from '@vercel/blob'
+
+async function migrate(): Promise<void> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error('BLOB_READ_WRITE_TOKEN not configured')
+  }
+
+  let cursor: string | undefined
+  let migrated = 0
+  let skipped = 0
+  let failed = 0
+
+  do {
+    const page = await list({ cursor, limit: 100 })
+
+    for (const blob of page.blobs) {
+      // Unauthenticated fetch: 200 means the blob is still public
+      const response = await fetch(blob.url)
+
+      if (response.status === 403 || response.status === 401) {
+        skipped += 1
+        continue
+      }
+
+      if (!response.ok) {
+        console.error(`FAILED ${blob.pathname}: fetch returned ${response.status}`)
+        failed += 1
+        continue
+      }
+
+      const contentType = response.headers.get('content-type') ?? 'application/octet-stream'
+      const body = Buffer.from(await response.arrayBuffer())
+
+      const result = await put(blob.pathname, body, {
+        access: 'private',
+        contentType,
+        allowOverwrite: true,
+      })
+
+      if (result.url !== blob.url) {
+        // Database rows store the old URL; flag any mismatch so those rows
+        // can be updated manually.
+        console.warn(`WARNING ${blob.pathname}: URL changed ${blob.url} -> ${result.url}`)
+      }
+
+      console.log(`migrated ${blob.pathname} (${body.length} bytes)`)
+      migrated += 1
+    }
+
+    cursor = page.cursor
+  } while (cursor)
+
+  console.log(`\nDone. migrated=${migrated} already-private=${skipped} failed=${failed}`)
+
+  if (failed > 0) {
+    process.exitCode = 1
+  }
+}
+
+migrate().catch((error) => {
+  console.error('Migration failed:', error)
+  process.exitCode = 1
+})

--- a/src/app/api/customers/[customerId]/knowledge/upload/route.ts
+++ b/src/app/api/customers/[customerId]/knowledge/upload/route.ts
@@ -63,7 +63,7 @@ export async function POST(
 
     // Upload file and parse content in parallel
     const [blob, content] = await Promise.all([
-      put(`knowledge/${auth.orgId}/${customerId}/${sanitizeFilename(file.name)}`, file, { access: 'public' }),
+      put(`knowledge/${auth.orgId}/${customerId}/${sanitizeFilename(file.name)}`, file, { access: 'private' }),
       file.arrayBuffer().then((buf) => {
         const buffer = Buffer.from(buf)
         if (file.name.endsWith('.pdf') || file.type === 'application/pdf') {

--- a/src/app/api/knowledge/upload/route.ts
+++ b/src/app/api/knowledge/upload/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
 
     // Upload file and parse content in parallel
     const [blob, content] = await Promise.all([
-      put(`knowledge/${auth.orgId}/company/${sanitizeFilename(file.name)}`, file, { access: 'public' }),
+      put(`knowledge/${auth.orgId}/company/${sanitizeFilename(file.name)}`, file, { access: 'private' }),
       file.arrayBuffer().then((buf) => {
         const buffer = Buffer.from(buf)
         if (file.name.endsWith('.pdf') || file.type === 'application/pdf') {

--- a/src/app/api/rfps/[rfpId]/download/route.ts
+++ b/src/app/api/rfps/[rfpId]/download/route.ts
@@ -3,6 +3,7 @@ import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { eq, and } from 'drizzle-orm'
+import { downloadFile } from '@/lib/storage/blob'
 
 export async function GET(
   request: NextRequest,
@@ -23,7 +24,23 @@ export async function GET(
     }
 
     if (rfp.completedFileUrl) {
-      return NextResponse.redirect(rfp.completedFileUrl, 302)
+      // Blobs are private — proxy the bytes rather than redirecting to the
+      // blob URL, which is not directly readable by the browser.
+      const buffer = await downloadFile(rfp.completedFileUrl)
+
+      const fileType = rfp.originalFileType === 'docx' ? 'docx' : 'pdf'
+      const contentType = fileType === 'pdf'
+        ? 'application/pdf'
+        : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+      return new Response(new Uint8Array(buffer), {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Content-Disposition': `attachment; filename="completed-rfp.${fileType}"`,
+          'Cache-Control': 'private, max-age=0',
+        },
+      })
     }
 
     return NextResponse.json(

--- a/src/app/api/rfps/[rfpId]/upload/route.ts
+++ b/src/app/api/rfps/[rfpId]/upload/route.ts
@@ -59,7 +59,7 @@ export async function POST(
 
     // Upload to Vercel Blob
     const pathname = `rfps/${rfpId}/${sanitizeFilename(file.name)}`
-    const blob = await put(pathname, file, { access: 'public' })
+    const blob = await put(pathname, file, { access: 'private' })
 
     // Update RFP with file URL
     await db

--- a/src/lib/storage/blob.ts
+++ b/src/lib/storage/blob.ts
@@ -1,4 +1,4 @@
-import { put, del } from '@vercel/blob'
+import { put, del, get } from '@vercel/blob'
 
 /**
  * Sanitizes a user-supplied filename for safe use in a blob storage pathname.
@@ -35,7 +35,7 @@ export async function uploadRfpDocument(
     : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
   const blob = await put(path, file, {
-    access: 'public',
+    access: 'private',
     contentType,
   })
 
@@ -43,10 +43,23 @@ export async function uploadRfpDocument(
 }
 
 /**
- * Downloads a file from a URL and returns it as a Buffer
- * @param url - The URL of the file to download
+ * Downloads a blob and returns it as a Buffer. Reads via the authenticated
+ * blob API (private access); blobs uploaded before the private-access
+ * migration are still public, so a plain fetch is used as a fallback until
+ * scripts/migrate-blobs-to-private.ts has been run.
+ * @param url - The blob URL to download
  */
 export async function downloadFile(url: string): Promise<Buffer> {
+  try {
+    const result = await get(url, { access: 'private' })
+    if (result?.stream) {
+      const arrayBuffer = await new Response(result.stream).arrayBuffer()
+      return Buffer.from(arrayBuffer)
+    }
+  } catch {
+    // Legacy public blob (or non-blob URL) — fall through to plain fetch
+  }
+
   const response = await fetch(url)
   if (!response.ok) {
     throw new Error(`Download failed: ${response.status} ${response.statusText}`)

--- a/tests/integration/api/knowledge-org.test.ts
+++ b/tests/integration/api/knowledge-org.test.ts
@@ -58,6 +58,7 @@ vi.mock('@/lib/inngest/client', () => ({
 }))
 
 vi.mock('@vercel/blob', () => ({
+  get: vi.fn(),
   put: vi.fn(() =>
     Promise.resolve({
       url: 'https://blob.vercel-storage.com/doc.pdf',

--- a/tests/integration/api/knowledge.test.ts
+++ b/tests/integration/api/knowledge.test.ts
@@ -64,6 +64,7 @@ vi.mock('@/lib/services/vector-search', () => ({
 }))
 
 vi.mock('@vercel/blob', () => ({
+  get: vi.fn(),
   put: vi.fn(() =>
     Promise.resolve({
       url: 'https://blob.vercel-storage.com/doc.pdf',

--- a/tests/integration/api/rfps.test.ts
+++ b/tests/integration/api/rfps.test.ts
@@ -58,6 +58,7 @@ vi.mock('@upstash/redis', () => ({
 }))
 
 vi.mock('@vercel/blob', () => ({
+  get: vi.fn(),
   put: vi.fn(() =>
     Promise.resolve({
       url: 'https://blob.vercel-storage.com/file.pdf',
@@ -676,6 +677,7 @@ describe('RFP API Routes - Contract Tests (TDD Red Phase)', () => {
                 {
                   id: 'rfp_1',
                   status: 'finalized',
+                  originalFileType: 'pdf',
                   completedFileUrl: 'https://blob.vercel-storage.com/completed.pdf',
                 },
               ])
@@ -684,12 +686,10 @@ describe('RFP API Routes - Contract Tests (TDD Red Phase)', () => {
         })),
       } as never)
 
-      // Mock fetch for blob download
+      // The @vercel/blob `get` mock returns undefined, so downloadFile
+      // falls back to plain fetch — mock that fetch here.
       global.fetch = vi.fn(() =>
-        Promise.resolve({
-          ok: true,
-          blob: () => Promise.resolve(new Blob(['PDF content'])),
-        } as Response)
+        Promise.resolve(new Response(Buffer.from('PDF content'), { status: 200 }))
       )
 
       const request = createMockRequest(
@@ -698,8 +698,9 @@ describe('RFP API Routes - Contract Tests (TDD Red Phase)', () => {
       )
       const response = await downloadRfp(request, { params: Promise.resolve({ rfpId: 'rfp_1' }) })
 
-      expect(response.status).toBe(302)
-      expect(response.headers.get('location')).toBeTruthy()
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toBe('application/pdf')
+      expect(response.headers.get('Content-Disposition')).toContain('attachment')
     })
 
     it('should return 404 if no completed file', async () => {

--- a/tests/unit/api/rfp-download.test.ts
+++ b/tests/unit/api/rfp-download.test.ts
@@ -12,6 +12,10 @@ vi.mock('@/lib/utils/auth', () => ({
   },
 }))
 
+vi.mock('@/lib/storage/blob', () => ({
+  downloadFile: vi.fn(),
+}))
+
 vi.mock('@/lib/db', () => {
   const limit = vi.fn()
   const chain = { select: vi.fn(), from: vi.fn(), where: vi.fn(), limit }
@@ -23,6 +27,7 @@ vi.mock('@/lib/db', () => {
 
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
 import { db } from '@/lib/db'
+import { downloadFile } from '@/lib/storage/blob'
 import { GET } from '@/app/api/rfps/[rfpId]/download/route'
 
 const mockUser = { userId: 'user-1', orgId: 'org-1', orgRole: 'org:member' }
@@ -61,18 +66,43 @@ describe('GET /api/rfps/[rfpId]/download', () => {
     expect(res.status).toBe(404)
   })
 
-  it('returns 302 redirect when completedFileUrl exists', async () => {
+  it('proxies the completed document bytes when completedFileUrl exists', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(db as any).limit.mockResolvedValue([{
       id: 'rfp-1',
       organizationId: 'org-1',
+      originalFileType: 'pdf',
       completedFileUrl: 'https://blob.example.com/completed.pdf',
       completedFileError: null,
     }])
+    vi.mocked(downloadFile).mockResolvedValue(Buffer.from([1, 2, 3]))
 
     const res = await GET(makeRequest(), makeParams())
-    expect(res.status).toBe(302)
-    expect(res.headers.get('Location')).toBe('https://blob.example.com/completed.pdf')
+    expect(res.status).toBe(200)
+    expect(downloadFile).toHaveBeenCalledWith('https://blob.example.com/completed.pdf')
+    expect(res.headers.get('Content-Type')).toBe('application/pdf')
+    expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="completed-rfp.pdf"')
+    const body = Buffer.from(await res.arrayBuffer())
+    expect(Array.from(body)).toEqual([1, 2, 3])
+  })
+
+  it('serves docx completed documents with the docx content type', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(db as any).limit.mockResolvedValue([{
+      id: 'rfp-1',
+      organizationId: 'org-1',
+      originalFileType: 'docx',
+      completedFileUrl: 'https://blob.example.com/completed.docx',
+      completedFileError: null,
+    }])
+    vi.mocked(downloadFile).mockResolvedValue(Buffer.from([4, 5]))
+
+    const res = await GET(makeRequest(), makeParams())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    )
+    expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="completed-rfp.docx"')
   })
 
   it('returns 404 with completedFileError when no URL and error exists', async () => {

--- a/tests/unit/storage/blob.test.ts
+++ b/tests/unit/storage/blob.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { uploadRfpDocument, deleteFile } from '@/lib/storage/blob'
+import { uploadRfpDocument, deleteFile, downloadFile } from '@/lib/storage/blob'
 
 // Mock @vercel/blob
 vi.mock('@vercel/blob', () => ({
   put: vi.fn(),
   del: vi.fn(),
+  get: vi.fn(),
 }))
 
-import { put, del } from '@vercel/blob'
+import { put, del, get } from '@vercel/blob'
 
 describe('Vercel Blob Storage', () => {
   beforeEach(() => {
@@ -34,7 +35,7 @@ describe('Vercel Blob Storage', () => {
         'org-123/rfp-456/proposal.pdf',
         file,
         {
-          access: 'public',
+          access: 'private',
           contentType: 'application/pdf',
         }
       )
@@ -58,7 +59,7 @@ describe('Vercel Blob Storage', () => {
         'org-123/rfp-456/proposal.docx',
         file,
         {
-          access: 'public',
+          access: 'private',
           contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         }
       )
@@ -106,6 +107,58 @@ describe('Vercel Blob Storage', () => {
 
       expect(result.url).toBe(mockBlob.url)
       expect(put).toHaveBeenCalled()
+    })
+  })
+
+  describe('downloadFile', () => {
+    function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      })
+    }
+
+    it('reads private blobs via authenticated get', async () => {
+      const bytes = new Uint8Array([1, 2, 3, 4])
+      vi.mocked(get).mockResolvedValue({ statusCode: 200, stream: streamOf(bytes) } as never)
+
+      const url = 'https://blob.vercel-storage.com/org-1/rfp-1/doc.pdf'
+      const buffer = await downloadFile(url)
+
+      expect(get).toHaveBeenCalledWith(url, { access: 'private' })
+      expect(Array.from(buffer)).toEqual([1, 2, 3, 4])
+    })
+
+    it('falls back to plain fetch for legacy public blobs', async () => {
+      vi.mocked(get).mockRejectedValue(new Error('Access denied'))
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(new Uint8Array([9, 8, 7]), { status: 200 })
+      )
+
+      try {
+        const buffer = await downloadFile('https://blob.vercel-storage.com/legacy.pdf')
+        expect(fetchSpy).toHaveBeenCalledWith('https://blob.vercel-storage.com/legacy.pdf')
+        expect(Array.from(buffer)).toEqual([9, 8, 7])
+      } finally {
+        fetchSpy.mockRestore()
+      }
+    })
+
+    it('throws when both authenticated get and fallback fetch fail', async () => {
+      vi.mocked(get).mockResolvedValue(null as never)
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(null, { status: 403, statusText: 'Forbidden' })
+      )
+
+      try {
+        await expect(downloadFile('https://blob.vercel-storage.com/gone.pdf')).rejects.toThrow(
+          'Download failed: 403'
+        )
+      } finally {
+        fetchSpy.mockRestore()
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

All blob uploads (RFP documents, org/customer knowledge files) used `access: 'public'`, meaning anyone holding a blob URL could read tenant documents with no authentication. This PR makes all uploads private and routes every read through the authenticated blob API.

## Changes

- **Uploads private**: `uploadRfpDocument` and the three upload routes now `put()` with `access: 'private'`
- **Authenticated reads**: `downloadFile` uses `get(url, { access: 'private' })`; falls back to a plain fetch for legacy public blobs uploaded before this change
- **Download route proxies bytes**: `GET /api/rfps/[rfpId]/download` previously 302-redirected the browser to the raw blob URL (impossible with private blobs); it now streams the bytes with `Content-Disposition: attachment` after the existing auth + org-ownership check
- **Migration script**: `scripts/migrate-blobs-to-private.ts` re-uploads legacy public blobs as private at the same pathname (URLs stay stable; warns if any URL changes). Run once after merge:
  ```
  BLOB_READ_WRITE_TOKEN=... npx tsx scripts/migrate-blobs-to-private.ts
  ```

No client-side changes needed — the document viewer already reads via the `/api/rfps/[rfpId]/document` proxy, and `DocumentPreview` never fetches the raw URL.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] Unit: blob storage (9), download route (6), document route (5) — all passing
- [x] Integration: rfps (23), knowledge (15), knowledge-org (11) — all passing
- [ ] After merge: run the migration script against the production blob store

🤖 Generated with [Claude Code](https://claude.com/claude-code)