### PR TITLE
fix: restore rate-limit headers on 429 responses via shared error helper

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, isAdmin, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { queryAnalyticsSnapshots, type AnalyticsFilters } from '@/lib/services/analytics'
 import { getRedis } from '@/lib/storage/kv'
 import crypto from 'crypto'
@@ -72,7 +73,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(response, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[GET /api/analytics]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/content-library/[entryId]/route.ts
+++ b/src/app/api/content-library/[entryId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { getEntry, updateEntry, deleteEntry } from '@/lib/services/proposal-content-library'
 
@@ -20,7 +21,7 @@ export async function GET(_request: NextRequest, { params }: Params) {
     return NextResponse.json({ entry }, { status: 200 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: 401 })
+      return authErrorResponse(err)
     }
     const statusCode = (err as { statusCode?: number }).statusCode
     if (statusCode === 404) {
@@ -43,7 +44,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
     return NextResponse.json({ entry }, { status: 200 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: 401 })
+      return authErrorResponse(err)
     }
     const statusCode = (err as { statusCode?: number }).statusCode
     if (statusCode === 400) {
@@ -64,7 +65,7 @@ export async function DELETE(_request: NextRequest, { params }: Params) {
     return new NextResponse(null, { status: 204 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: 401 })
+      return authErrorResponse(err)
     }
     const statusCode = (err as { statusCode?: number }).statusCode
     if (statusCode === 403) {

--- a/src/app/api/content-library/embed/route.ts
+++ b/src/app/api/content-library/embed/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { proposalContentLibrary } from '@/lib/db/schema/proposal-content-library'
 import { eq, and, isNull } from 'drizzle-orm'
@@ -31,7 +32,7 @@ export async function POST() {
     return NextResponse.json({ count: unembedded.length, queued: true }, { status: 202 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/content-library/route.ts
+++ b/src/app/api/content-library/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { createEntry, listEntries, ensureFixedSections } from '@/lib/services/proposal-content-library'
 
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ entries }, { status: 200 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: 401 })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -39,7 +40,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ entry }, { status: 201 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: 401 })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/content-library/search/route.ts
+++ b/src/app/api/content-library/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { searchContentLibrary } from '@/lib/services/content-library-search'
 
 export async function GET(request: NextRequest) {
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ entries }, { status: 200 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/customers/[customerId]/knowledge/[entryId]/route.ts
+++ b/src/app/api/customers/[customerId]/knowledge/[entryId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { knowledgeEntries } from '@/lib/db/schema/knowledge-entries'
 import { eq, and } from 'drizzle-orm'
@@ -41,7 +42,7 @@ export async function GET(
     return NextResponse.json({ entry }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -72,7 +73,7 @@ export async function DELETE(
     return new Response(null, { status: 204 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/customers/[customerId]/knowledge/route.ts
+++ b/src/app/api/customers/[customerId]/knowledge/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { knowledgeEntries, KnowledgeEntryType } from '@/lib/db/schema/knowledge-entries'
@@ -46,7 +47,7 @@ export async function GET(
     return NextResponse.json({ entries }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -101,7 +102,7 @@ export async function POST(
     return NextResponse.json({ entry: created }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/customers/[customerId]/knowledge/search/route.ts
+++ b/src/app/api/customers/[customerId]/knowledge/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { knowledgeSearchSchema } from '@/lib/utils/validation'
 import { searchSimilar } from '@/lib/services/vector-search'
@@ -31,7 +32,7 @@ export async function POST(
     return NextResponse.json({ results }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/customers/[customerId]/knowledge/upload/route.ts
+++ b/src/app/api/customers/[customerId]/knowledge/upload/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse, after } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { knowledgeEntries, KnowledgeEntryType } from '@/lib/db/schema/knowledge-entries'
 import { customers } from '@/lib/db/schema/customers'
@@ -123,7 +124,7 @@ export async function POST(
     return NextResponse.json({ entry: created }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[POST /api/customers/knowledge/upload]', error instanceof Error ? error.message : String(error))
     const message =

--- a/src/app/api/customers/[customerId]/route.ts
+++ b/src/app/api/customers/[customerId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { customers } from '@/lib/db/schema/customers'
@@ -44,7 +45,7 @@ export async function GET(
     }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -80,7 +81,7 @@ export async function PATCH(
     return NextResponse.json({ customer: updated }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -105,7 +106,7 @@ export async function DELETE(
     return new Response(null, { status: 204 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { customers } from '@/lib/db/schema/customers'
@@ -18,7 +19,7 @@ export async function GET() {
     return NextResponse.json({ customers: customersList }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -50,7 +51,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ customer: created }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/knowledge/[entryId]/route.ts
+++ b/src/app/api/knowledge/[entryId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { knowledgeEntries } from '@/lib/db/schema/knowledge-entries'
 import { eq, and, isNull } from 'drizzle-orm'
@@ -29,7 +30,7 @@ export async function DELETE(
     return new Response(null, { status: 204 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { knowledgeEntries, KnowledgeEntryType } from '@/lib/db/schema/knowledge-entries'
@@ -40,7 +41,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ entries }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -88,7 +89,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ entry: created }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/knowledge/upload/route.ts
+++ b/src/app/api/knowledge/upload/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse, after } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { knowledgeEntries, KnowledgeEntryType } from '@/lib/db/schema/knowledge-entries'
 import { inngest } from '@/lib/inngest/client'
@@ -106,7 +107,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ entry: created }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[POST /api/knowledge/upload]', error instanceof Error ? error.message : String(error))
     const message =

--- a/src/app/api/learnings/route.ts
+++ b/src/app/api/learnings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { learnings } from '@/lib/db/schema'
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ learnings: rows })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -47,7 +48,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ learning }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/approve/route.ts
+++ b/src/app/api/rfps/[rfpId]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { validateTransition, WorkflowError } from '@/lib/services/rfp-workflow'
@@ -60,7 +61,7 @@ export async function POST(
     return NextResponse.json({ rfp: updated })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     if (error instanceof WorkflowError) {
       return NextResponse.json({ error: error.message }, { status: error.statusCode })

--- a/src/app/api/rfps/[rfpId]/assign/route.ts
+++ b/src/app/api/rfps/[rfpId]/assign/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
@@ -52,7 +53,7 @@ export async function POST(
     return NextResponse.json({ rfp: updated[0] })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/rfps/[rfpId]/document/route.ts
+++ b/src/app/api/rfps/[rfpId]/document/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { eq, and } from 'drizzle-orm'
@@ -43,7 +44,7 @@ export async function GET(
     })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/download/route.ts
+++ b/src/app/api/rfps/[rfpId]/download/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { eq, and } from 'drizzle-orm'
@@ -52,7 +53,7 @@ export async function GET(
     )
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/finalize/route.ts
+++ b/src/app/api/rfps/[rfpId]/finalize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { validateTransition, WorkflowError } from '@/lib/services/rfp-workflow'
@@ -48,7 +49,7 @@ export async function POST(
     return NextResponse.json({ rfp: updated, documentGenerationQueued: true })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     if (error instanceof WorkflowError) {
       return NextResponse.json({ error: error.message }, { status: error.statusCode })

--- a/src/app/api/rfps/[rfpId]/outcome/route.ts
+++ b/src/app/api/rfps/[rfpId]/outcome/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
@@ -91,7 +92,7 @@ export async function PATCH(
     return NextResponse.json({ rfp: updated }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[PATCH /api/rfps/[rfpId]/outcome]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/rfps/[rfpId]/presence/route.ts
+++ b/src/app/api/rfps/[rfpId]/presence/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { getRedis } from '@/lib/storage/kv'
 
@@ -52,7 +53,7 @@ export async function GET(
     return NextResponse.json({ viewers }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -85,7 +86,7 @@ export async function POST(
     return NextResponse.json({ ok: true }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/rfps/[rfpId]/process/route.ts
+++ b/src/app/api/rfps/[rfpId]/process/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { inngest } from '@/lib/inngest/client'
@@ -47,7 +48,7 @@ export async function POST(
     )
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/proposals/[draftId]/answers/route.ts
+++ b/src/app/api/rfps/[rfpId]/proposals/[draftId]/answers/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { submitAnswers } from '@/lib/services/proposal-draft'
 
 type Params = { params: Promise<{ rfpId: string; draftId: string }> }
@@ -35,7 +36,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     return NextResponse.json({ draft }, { status: 202 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     const statusCode = (err as NodeJS.ErrnoException & { statusCode?: number }).statusCode
     if (statusCode === 404) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/src/app/api/rfps/[rfpId]/proposals/[draftId]/coverage/route.ts
+++ b/src/app/api/rfps/[rfpId]/proposals/[draftId]/coverage/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { proposalDrafts, rfps, proposalTemplates } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
@@ -59,7 +60,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     return NextResponse.json(coverageReport)
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Coverage evaluation failed' }, { status: 500 })
   }

--- a/src/app/api/rfps/[rfpId]/proposals/[draftId]/export/route.ts
+++ b/src/app/api/rfps/[rfpId]/proposals/[draftId]/export/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { getDraft } from '@/lib/services/proposal-draft'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema'
@@ -42,7 +43,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/rfps/[rfpId]/proposals/[draftId]/route.ts
+++ b/src/app/api/rfps/[rfpId]/proposals/[draftId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { getDraft, updateDraft, cancelDraft } from '@/lib/services/proposal-draft'
 
@@ -17,7 +18,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     return NextResponse.json(draft)
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -37,7 +38,7 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     return NextResponse.json(draft)
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     const statusCode = (err as NodeJS.ErrnoException & { statusCode?: number }).statusCode
     if (statusCode === 404) return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -55,7 +56,7 @@ export async function DELETE(req: NextRequest, { params }: Params) {
     return NextResponse.json(draft)
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     const statusCode = (err as NodeJS.ErrnoException & { statusCode?: number }).statusCode
     if (statusCode === 404) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/src/app/api/rfps/[rfpId]/proposals/route.ts
+++ b/src/app/api/rfps/[rfpId]/proposals/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { createDraft, listDrafts } from '@/lib/services/proposal-draft'
 
 type Params = { params: Promise<{ rfpId: string }> }
@@ -13,7 +14,7 @@ export async function GET(req: NextRequest, { params }: Params) {
     return NextResponse.json({ drafts })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -29,7 +30,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     return NextResponse.json({ draft }, { status: 201 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     const statusCode = (err as NodeJS.ErrnoException & { statusCode?: number }).statusCode
     if (statusCode === 422) {

--- a/src/app/api/rfps/[rfpId]/responses/[fieldId]/feedback/route.ts
+++ b/src/app/api/rfps/[rfpId]/responses/[fieldId]/feedback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { inngest } from '@/lib/inngest/client'
 import { db } from '@/lib/db'
@@ -49,7 +50,7 @@ export async function POST(
     return NextResponse.json({ queued: true }, { status: 202 })
   } catch (err) {
     if (err instanceof AuthError) {
-      return NextResponse.json({ error: err.message }, { status: err.statusCode })
+      return authErrorResponse(err)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/rfps/[rfpId]/responses/[fieldId]/route.ts
+++ b/src/app/api/rfps/[rfpId]/responses/[fieldId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { rfpResponses } from '@/lib/db/schema/rfp-responses'
@@ -121,7 +122,7 @@ export async function PUT(
     return NextResponse.json({ response: updatedResponse }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/responses/route.ts
+++ b/src/app/api/rfps/[rfpId]/responses/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfpResponses } from '@/lib/db/schema/rfp-responses'
 import { eq } from 'drizzle-orm'
@@ -20,7 +21,7 @@ export async function GET(
     return NextResponse.json({ responses }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/return/route.ts
+++ b/src/app/api/rfps/[rfpId]/return/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
@@ -66,7 +67,7 @@ export async function POST(
     return NextResponse.json({ rfp: updated })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     if (error instanceof WorkflowError) {
       return NextResponse.json({ error: error.message }, { status: error.statusCode })

--- a/src/app/api/rfps/[rfpId]/route.ts
+++ b/src/app/api/rfps/[rfpId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, isAdmin, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { eq, and } from 'drizzle-orm'
@@ -40,7 +41,7 @@ export async function GET(
     return NextResponse.json({ rfp: decryptRfpPii(rfp) }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -89,7 +90,7 @@ export async function PUT(
     return NextResponse.json({ rfp: decryptRfpPii(updatedRfp) }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -114,7 +115,7 @@ export async function DELETE(
     return new Response(null, { status: 204 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/status/route.ts
+++ b/src/app/api/rfps/[rfpId]/status/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { rfpResponses } from '@/lib/db/schema/rfp-responses'
@@ -43,7 +44,7 @@ export async function GET(
     )
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/stream/route.ts
+++ b/src/app/api/rfps/[rfpId]/stream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { eq, and } from 'drizzle-orm'
@@ -74,7 +75,7 @@ export async function GET(
     })
   } catch (error) {
     if (error instanceof AuthError) {
-      return new Response(JSON.stringify({ error: error.message }), { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 })
   }

--- a/src/app/api/rfps/[rfpId]/submit/route.ts
+++ b/src/app/api/rfps/[rfpId]/submit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { validateTransition, WorkflowError } from '@/lib/services/rfp-workflow'
@@ -35,7 +36,7 @@ export async function POST(
     return NextResponse.json({ rfp: updated })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     if (error instanceof WorkflowError) {
       return NextResponse.json({ error: error.message }, { status: error.statusCode })

--- a/src/app/api/rfps/[rfpId]/upload/route.ts
+++ b/src/app/api/rfps/[rfpId]/upload/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { put } from '@vercel/blob'
@@ -75,7 +76,7 @@ export async function POST(
     return NextResponse.json({ url: `/api/rfps/${rfpId}/document` }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/[rfpId]/versions/route.ts
+++ b/src/app/api/rfps/[rfpId]/versions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
 import { rfpVersions } from '@/lib/db/schema/rfp-versions'
@@ -32,7 +33,7 @@ export async function GET(
     return NextResponse.json({ versions })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/rfps/route.ts
+++ b/src/app/api/rfps/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, isAdmin, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { rfps } from '@/lib/db/schema/rfps'
@@ -57,7 +58,7 @@ export async function GET() {
     return NextResponse.json({ rfps: rfpsList.map(decryptRfpPii) }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -128,7 +129,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ rfp: createdRfp }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/app/api/settings/company-profile/route.ts
+++ b/src/app/api/settings/company-profile/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { getCompanyProfile, upsertCompanyProfile } from '@/lib/services/company-profile'
 import { updateCompanyProfileSchema } from '@/lib/utils/validation'
 
@@ -10,7 +11,7 @@ export async function GET() {
     return NextResponse.json(result)
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[GET /api/settings/company-profile]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
@@ -47,7 +48,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ success: true })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[PATCH /api/settings/company-profile]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/settings/integrations/[type]/route.ts
+++ b/src/app/api/settings/integrations/[type]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import {
   upsertIntegrationConfig,
@@ -34,7 +35,7 @@ export async function PUT(
     return NextResponse.json({ integration: summary }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -59,7 +60,7 @@ export async function DELETE(
     return new NextResponse(null, { status: 204 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/settings/integrations/[type]/test/route.ts
+++ b/src/app/api/settings/integrations/[type]/test/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { getIntegrationConfigWithCredentials, type IntegrationType } from '@/lib/services/integration-config'
 
 const VALID_TYPES: IntegrationType[] = ['slack', 'salesforce', 'hubspot']
@@ -66,7 +67,7 @@ export async function POST(
     return NextResponse.json({ success: false, message: 'Unknown integration type' }, { status: 400 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/settings/integrations/route.ts
+++ b/src/app/api/settings/integrations/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireAuthLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { listIntegrationConfigs } from '@/lib/services/integration-config'
 
 export async function GET() {
@@ -9,7 +10,7 @@ export async function GET() {
     return NextResponse.json({ integrations: configs }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/settings/integrations/sync-events/[syncEventId]/retry/route.ts
+++ b/src/app/api/settings/integrations/sync-events/[syncEventId]/retry/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { getSyncEvent } from '@/lib/services/integration-config'
 import { inngest } from '@/lib/inngest/client'
 
@@ -31,7 +32,7 @@ export async function POST(
     return NextResponse.json({ ok: true, syncEventId }, { status: 202 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/settings/integrations/sync-events/route.ts
+++ b/src/app/api/settings/integrations/sync-events/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { listSyncEvents, type SyncEventFilters } from '@/lib/services/integration-config'
 import type { SyncEventStatus } from '@/lib/db/schema/sync-events'
 import type { IntegrationType } from '@/lib/services/integration-config'
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ events }, { status: 200 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/settings/proposal-templates/[id]/route.ts
+++ b/src/app/api/settings/proposal-templates/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import {
   updateProposalTemplate,
   deleteProposalTemplate,
@@ -50,7 +51,7 @@ export async function PATCH(
     return NextResponse.json({ template })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     if (error instanceof Error && error.message === 'isRequired and evaluateCoverage cannot both be true') {
       return NextResponse.json({ error: error.message }, { status: 422 })
@@ -80,7 +81,7 @@ export async function DELETE(
     return new NextResponse(null, { status: 204 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[DELETE /api/settings/proposal-templates/[id]]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/settings/proposal-templates/reorder/route.ts
+++ b/src/app/api/settings/proposal-templates/reorder/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { reorderProposalTemplates } from '@/lib/services/proposalTemplates'
 import { reorderProposalTemplatesSchema } from '@/lib/utils/validation'
 
@@ -32,7 +33,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     if (error instanceof Error && error.message === 'INVALID_IDS') {
       return NextResponse.json(

--- a/src/app/api/settings/proposal-templates/route.ts
+++ b/src/app/api/settings/proposal-templates/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import {
   listProposalTemplates,
   createProposalTemplate,
@@ -13,7 +14,7 @@ export async function GET() {
     return NextResponse.json({ templates })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[GET /api/settings/proposal-templates]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
@@ -49,7 +50,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ template }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[POST /api/settings/proposal-templates]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/settings/rate-card/route.ts
+++ b/src/app/api/settings/rate-card/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdminLimited, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { getRateCard, upsertRateCard } from '@/lib/services/rate-card'
 import { createRateCardPatchSchema } from '@/lib/utils/validation'
 
@@ -10,7 +11,7 @@ export async function GET() {
     return NextResponse.json(result)
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[GET /api/settings/rate-card]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
@@ -47,7 +48,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ success: true })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[PATCH /api/settings/rate-card]', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAuthLimited, isAdmin, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 import { db } from '@/lib/db'
 import { tenantSettings, llmProviders } from '@/lib/db/schema'
@@ -60,7 +61,7 @@ export async function GET() {
   } catch (error) {
     console.error('[GET /api/settings]', error)
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -125,7 +126,7 @@ export async function PATCH(request: NextRequest) {
   } catch (error) {
     console.error('[PATCH /api/settings]', error)
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }

--- a/src/app/api/users/invite/route.ts
+++ b/src/app/api/users/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { clerkClient } from '@clerk/nextjs/server'
 import { requireAuthLimited, isAdmin, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 
 export async function POST(request: NextRequest) {
@@ -33,7 +34,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ invitation }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     console.error('[POST /api/users/invite]', error instanceof Error ? error.message : String(error))
     const message =

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { clerkClient } from '@clerk/nextjs/server'
 import { requireAuthLimited, isAdmin, AuthError } from '@/lib/utils/auth'
+import { authErrorResponse } from '@/lib/utils/api-error'
 import { readJsonBody } from '@/lib/utils/request'
 
 export async function GET() {
@@ -29,7 +30,7 @@ export async function GET() {
     )
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }
@@ -65,7 +66,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ invitation }, { status: 201 })
   } catch (error) {
     if (error instanceof AuthError) {
-      return NextResponse.json({ error: error.message }, { status: error.statusCode })
+      return authErrorResponse(error)
     }
     throw error
   }

--- a/src/lib/utils/api-error.ts
+++ b/src/lib/utils/api-error.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import type { AuthError } from './auth'
+
+/**
+ * Standard JSON response for an AuthError thrown by route helpers
+ * (requireAuthLimited, requireAdminLimited, readJsonBody, ...). Includes any
+ * headers attached to the error, e.g. rate-limit headers on a 429.
+ *
+ * Type-only dependency on the auth module so that test files mocking
+ * '@/lib/utils/auth' don't need to stub this helper.
+ */
+export function authErrorResponse(error: AuthError): NextResponse {
+  return NextResponse.json(
+    { error: error.message },
+    { status: error.statusCode, headers: error.headers }
+  )
+}

--- a/src/lib/utils/auth.ts
+++ b/src/lib/utils/auth.ts
@@ -1,5 +1,5 @@
 import { auth } from '@clerk/nextjs/server'
-import { checkRateLimit, type RateLimitTier } from './rate-limit'
+import { checkRateLimit, rateLimitHeaders, type RateLimitTier } from './rate-limit'
 
 export interface AuthContext {
   userId: string
@@ -38,7 +38,7 @@ export async function requireAuthLimited(tier: RateLimitTier = 'standard'): Prom
   const context = await requireAuth()
   const limited = await checkRateLimit(context.userId, tier)
   if (limited) {
-    throw new AuthError('Too many requests', 429)
+    throw new AuthError('Too many requests', 429, rateLimitHeaders(limited))
   }
   return context
 }
@@ -48,7 +48,7 @@ export async function requireAdminLimited(tier: RateLimitTier = 'standard'): Pro
   const context = await requireAdmin()
   const limited = await checkRateLimit(context.userId, tier)
   if (limited) {
-    throw new AuthError('Too many requests', 429)
+    throw new AuthError('Too many requests', 429, rateLimitHeaders(limited))
   }
   return context
 }
@@ -60,7 +60,9 @@ export function isAdmin(orgRole: string): boolean {
 export class AuthError extends Error {
   constructor(
     message: string,
-    public statusCode: number
+    public statusCode: number,
+    /** Extra response headers, e.g. rate-limit and Retry-After headers on a 429. */
+    public headers?: Record<string, string>
   ) {
     super(message)
     this.name = 'AuthError'

--- a/src/lib/utils/rate-limit.ts
+++ b/src/lib/utils/rate-limit.ts
@@ -1,5 +1,4 @@
 import { Ratelimit } from '@upstash/ratelimit'
-import { NextResponse } from 'next/server'
 import { getRedis } from '@/lib/storage/kv'
 
 export type RateLimitTier = 'standard' | 'strict' | 'upload'
@@ -29,15 +28,31 @@ function getLimiters(): Record<RateLimitTier, Ratelimit> | null {
   return _limiters
 }
 
+export interface RateLimitExceeded {
+  limit: number
+  remaining: number
+  reset: number
+}
+
+/** Builds the standard rate-limit response headers for a 429. */
+export function rateLimitHeaders(info: RateLimitExceeded): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': info.limit.toString(),
+    'X-RateLimit-Remaining': info.remaining.toString(),
+    'X-RateLimit-Reset': info.reset.toString(),
+    'Retry-After': Math.max(0, Math.ceil((info.reset - Date.now()) / 1000)).toString(),
+  }
+}
+
 /**
  * Check rate limit for a given identifier (typically userId or orgId).
- * Returns null if allowed, or a NextResponse with 429 if rate-limited.
+ * Returns null if allowed, or the limit details when rate-limited.
  * Skips rate limiting gracefully when Redis is unavailable.
  */
 export async function checkRateLimit(
   identifier: string,
   tier: RateLimitTier = 'standard'
-): Promise<NextResponse | null> {
+): Promise<RateLimitExceeded | null> {
   const limiters = getLimiters()
   if (!limiters) return null // Redis unavailable — allow request
 
@@ -46,18 +61,7 @@ export async function checkRateLimit(
     const { success, limit, remaining, reset } = await limiter.limit(identifier)
 
     if (!success) {
-      return NextResponse.json(
-        { error: 'Too many requests' },
-        {
-          status: 429,
-          headers: {
-            'X-RateLimit-Limit': limit.toString(),
-            'X-RateLimit-Remaining': remaining.toString(),
-            'X-RateLimit-Reset': reset.toString(),
-            'Retry-After': Math.ceil((reset - Date.now()) / 1000).toString(),
-          },
-        }
-      )
+      return { limit, remaining, reset }
     }
   } catch (error) {
     console.error('[rate-limit] Redis unreachable, allowing request:', error instanceof Error ? error.message : String(error))

--- a/tests/unit/utils/api-error.test.ts
+++ b/tests/unit/utils/api-error.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { authErrorResponse } from '@/lib/utils/api-error'
+import { AuthError } from '@/lib/utils/auth'
+import { rateLimitHeaders } from '@/lib/utils/rate-limit'
+
+describe('authErrorResponse', () => {
+  it('builds a JSON response from statusCode and message', async () => {
+    const res = authErrorResponse(new AuthError('Authentication required', 401))
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error).toBe('Authentication required')
+  })
+
+  it('includes headers attached to the error', async () => {
+    const res = authErrorResponse(
+      new AuthError('Too many requests', 429, {
+        'X-RateLimit-Limit': '60',
+        'X-RateLimit-Remaining': '0',
+        'Retry-After': '30',
+      })
+    )
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('60')
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('0')
+    expect(res.headers.get('Retry-After')).toBe('30')
+  })
+
+  it('omits rate-limit headers when the error has none', () => {
+    const res = authErrorResponse(new AuthError('Admin access required', 403))
+
+    expect(res.status).toBe(403)
+    expect(res.headers.get('X-RateLimit-Limit')).toBeNull()
+    expect(res.headers.get('Retry-After')).toBeNull()
+  })
+})
+
+describe('rateLimitHeaders', () => {
+  it('formats limit, remaining, reset and Retry-After', () => {
+    const reset = Date.now() + 45_000
+    const headers = rateLimitHeaders({ limit: 60, remaining: 0, reset })
+
+    expect(headers['X-RateLimit-Limit']).toBe('60')
+    expect(headers['X-RateLimit-Remaining']).toBe('0')
+    expect(headers['X-RateLimit-Reset']).toBe(reset.toString())
+    const retryAfter = Number(headers['Retry-After'])
+    expect(retryAfter).toBeGreaterThan(0)
+    expect(retryAfter).toBeLessThanOrEqual(45)
+  })
+
+  it('clamps Retry-After to zero for past reset timestamps', () => {
+    const headers = rateLimitHeaders({ limit: 60, remaining: 0, reset: Date.now() - 1000 })
+    expect(headers['Retry-After']).toBe('0')
+  })
+})

--- a/tests/unit/utils/auth.test.ts
+++ b/tests/unit/utils/auth.test.ts
@@ -5,6 +5,12 @@ vi.mock('@clerk/nextjs/server', () => ({
   auth: vi.fn(),
 }))
 
+// Mock only checkRateLimit; keep the real rateLimitHeaders
+vi.mock('@/lib/utils/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils/rate-limit')>()
+  return { ...actual, checkRateLimit: vi.fn().mockResolvedValue(null) }
+})
+
 describe('Auth Utilities', () => {
   let mockAuth: ReturnType<typeof vi.fn>
 
@@ -183,6 +189,91 @@ describe('Auth Utilities', () => {
         expect(error).toBeInstanceOf(AuthError)
         expect((error as { statusCode: number }).statusCode).toBe(401)
       }
+    })
+  })
+
+  describe('requireAuthLimited', () => {
+    it('returns auth context when not rate-limited', async () => {
+      mockAuth.mockResolvedValue({
+        userId: 'user_123',
+        orgId: 'org_456',
+        orgRole: 'org:member',
+      })
+      const { checkRateLimit } = await import('@/lib/utils/rate-limit')
+      vi.mocked(checkRateLimit).mockResolvedValue(null)
+
+      const { requireAuthLimited } = await import('@/lib/utils/auth')
+      const result = await requireAuthLimited('strict')
+
+      expect(result.userId).toBe('user_123')
+      expect(checkRateLimit).toHaveBeenCalledWith('user_123', 'strict')
+    })
+
+    it('throws AuthError 429 with rate-limit headers when limited', async () => {
+      mockAuth.mockResolvedValue({
+        userId: 'user_123',
+        orgId: 'org_456',
+        orgRole: 'org:member',
+      })
+      const reset = Date.now() + 30_000
+      const { checkRateLimit } = await import('@/lib/utils/rate-limit')
+      vi.mocked(checkRateLimit).mockResolvedValue({ limit: 60, remaining: 0, reset })
+
+      const { requireAuthLimited, AuthError } = await import('@/lib/utils/auth')
+
+      try {
+        await requireAuthLimited()
+        expect.unreachable('should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthError)
+        const authError = error as InstanceType<typeof AuthError>
+        expect(authError.statusCode).toBe(429)
+        expect(authError.headers).toMatchObject({
+          'X-RateLimit-Limit': '60',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': reset.toString(),
+        })
+        expect(Number(authError.headers!['Retry-After'])).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('requireAdminLimited', () => {
+    it('throws AuthError 429 with headers for rate-limited admin', async () => {
+      mockAuth.mockResolvedValue({
+        userId: 'user_123',
+        orgId: 'org_456',
+        orgRole: 'org:admin',
+      })
+      const { checkRateLimit } = await import('@/lib/utils/rate-limit')
+      vi.mocked(checkRateLimit).mockResolvedValue({ limit: 10, remaining: 0, reset: Date.now() + 1000 })
+
+      const { requireAdminLimited, AuthError } = await import('@/lib/utils/auth')
+
+      try {
+        await requireAdminLimited('strict')
+        expect.unreachable('should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(AuthError)
+        const authError = error as InstanceType<typeof AuthError>
+        expect(authError.statusCode).toBe(429)
+        expect(authError.headers!['X-RateLimit-Limit']).toBe('10')
+      }
+    })
+
+    it('throws 403 before consuming rate limit for non-admin', async () => {
+      mockAuth.mockResolvedValue({
+        userId: 'user_123',
+        orgId: 'org_456',
+        orgRole: 'org:member',
+      })
+      const { checkRateLimit } = await import('@/lib/utils/rate-limit')
+      vi.mocked(checkRateLimit).mockResolvedValue(null)
+
+      const { requireAdminLimited } = await import('@/lib/utils/auth')
+
+      await expect(requireAdminLimited()).rejects.toThrow('Admin access required')
+      expect(checkRateLimit).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Summary

PR #316's `requireAuthLimited`/`requireAdminLimited` wrappers threw a bare `AuthError(429)`, so 429 responses lost the `X-RateLimit-*` and `Retry-After` headers that the old inline `checkRateLimit` responses carried. This PR restores them through a single shared error-response helper.

## Changes

- **`checkRateLimit`** now returns `{ limit, remaining, reset } | null` instead of a pre-built `NextResponse`; new `rateLimitHeaders()` formats the standard headers (with `Retry-After` clamped to ≥ 0)
- **`AuthError`** gains an optional `headers` field; the `*Limited` helpers attach rate-limit headers when throwing 429
- **New `authErrorResponse(error)`** in `src/lib/utils/api-error.ts` builds the JSON error response including attached headers. It has only a *type-level* dependency on the auth module, so the 25+ test files mocking `@/lib/utils/auth` need no changes
- **All 76 `AuthError` catch blocks across 53 route files** converted to use it (mechanical sweep; per-route 500 fallbacks, `WorkflowError` handling, etc. untouched)
- **Side fix**: content-library routes hardcoded `status: 401` for every `AuthError` — they now return the error's real status (403 for admin failures, 429 when rate-limited)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on `src/app/api`, `src/lib/utils`, `tests/unit/utils`
- [x] New tests: `requireAuthLimited`/`requireAdminLimited` header propagation (auth.test.ts, 18 passing), `authErrorResponse` + `rateLimitHeaders` (api-error.test.ts, 5 passing)
- [x] Representative integration suites green: rfps (23), content-library (18), proposals (12), settings (10), rate-card (20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)