### PR TITLE
[codex] fix RFP upload error handling

### DIFF
--- a/src/app/(auth)/rfps/new/page.tsx
+++ b/src/app/(auth)/rfps/new/page.tsx
@@ -22,6 +22,18 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
+async function getApiError(response: Response, fallback: string): Promise<string> {
+  const text = await response.text()
+  if (!text) return fallback
+
+  try {
+    const body = JSON.parse(text) as { error?: unknown }
+    return typeof body.error === 'string' && body.error ? body.error : fallback
+  } catch {
+    return text || fallback
+  }
+}
+
 function StepIndicator({ step }: { step: number }) {
   const steps = ['Details', 'Upload', 'Review']
   return (
@@ -104,8 +116,7 @@ export default function NewRfpPage() {
         body: JSON.stringify({ name: rfpName, customerId }),
       })
       if (!createRes.ok) {
-        const err = await createRes.json()
-        throw new Error(err.error ?? 'Failed to create RFP')
+        throw new Error(await getApiError(createRes, 'Failed to create RFP'))
       }
       const { rfp } = await createRes.json()
 
@@ -117,8 +128,7 @@ export default function NewRfpPage() {
         body: formData,
       })
       if (!uploadRes.ok) {
-        const err = await uploadRes.json()
-        throw new Error(err.error ?? 'Failed to upload file')
+        throw new Error(await getApiError(uploadRes, 'Failed to upload file'))
       }
 
       // Step 3: Trigger processing
@@ -126,8 +136,7 @@ export default function NewRfpPage() {
         method: 'POST',
       })
       if (!processRes.ok) {
-        const err = await processRes.json()
-        throw new Error(err.error ?? 'Failed to start processing')
+        throw new Error(await getApiError(processRes, 'Failed to start processing'))
       }
 
       router.push(`/rfps/${rfp.id}`)

--- a/src/app/api/rfps/[rfpId]/upload/route.ts
+++ b/src/app/api/rfps/[rfpId]/upload/route.ts
@@ -78,6 +78,9 @@ export async function POST(
     if (error instanceof AuthError) {
       return authErrorResponse(error)
     }
-    throw error
+    console.error('[POST /api/rfps/upload]', error instanceof Error ? error.message : String(error))
+    const message =
+      error instanceof Error ? error.message : 'Failed to upload document'
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/tests/integration/api/rfps.test.ts
+++ b/tests/integration/api/rfps.test.ts
@@ -458,6 +458,37 @@ describe('RFP API Routes - Contract Tests (TDD Red Phase)', () => {
       const data = await response.json()
       expect(data.error).toBeDefined()
     })
+
+    it('should return JSON when blob upload fails', async () => {
+      vi.mocked(requireAuthLimited).mockResolvedValue(mockAuthContext)
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() => Promise.resolve([{ id: 'rfp_1' }])),
+          })),
+        })),
+      } as never)
+      vi.mocked(blobPut).mockRejectedValueOnce(new Error('Blob storage unavailable'))
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const formData = new FormData()
+      const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+      formData.append('file', file)
+
+      const request = createMockFormDataRequest(
+        'POST',
+        'http://localhost:3000/api/rfps/rfp_1/upload',
+        formData
+      )
+      const response = await uploadFile(request, { params: Promise.resolve({ rfpId: 'rfp_1' }) })
+
+      expect(response.status).toBe(500)
+      expect(response.headers.get('content-type')).toContain('application/json')
+      const data = await response.json()
+      expect(data.error).toBe('Blob storage unavailable')
+
+      consoleError.mockRestore()
+    })
   })
 
   describe('POST /api/rfps/[rfpId]/process', () => {


### PR DESCRIPTION
## Summary
- return JSON for unexpected RFP upload failures instead of framework 500 responses
- make the new-RFP submit flow tolerate empty or non-JSON error responses
- add regression coverage for blob upload failure responses

## Root cause
The upload API rethrew non-auth failures, so storage or database errors could produce a non-JSON 500. The client then called response.json() unconditionally and replaced the useful failure with Unexpected end of JSON input.

## Validation
- npm test -- tests/integration/api/rfps.test.ts
- npm run type-check
- git diff --check